### PR TITLE
Updates for the ReadTheDocs build process.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,6 +17,6 @@ sphinx:
 
 # We recommend specifying your dependencies to enable reproducible builds:
 # https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#   install:
-#   - requirements: docs/requirements.txt
+python:
+  install:
+  - requirements: requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+sphinx_rtd_theme

--- a/source/conf.py
+++ b/source/conf.py
@@ -30,7 +30,7 @@
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []
+extensions = ['sphinx_rtd_theme']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
I have updated and added configuration files for the ReadTheDocs build process. This was necessary as the build process was failing on this error:
"no theme named 'sphinx_rtd_theme' found (missing theme.conf?)"

I found instructions here: 
[How to install and use the theme](https://sphinx-rtd-theme.readthedocs.io/en/stable/installing.html)

I have tested and gotten a successful build on a ReadTheDocs instance for my fork of the tahoma2d_docs project.